### PR TITLE
Add hello_world.rb to gemspec

### DIFF
--- a/job_interview.gemspec
+++ b/job_interview.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
                       'lib/job_interview/fizz_buzz.rb',
                       'lib/job_interview/knapsack.rb',
                       'lib/job_interview/answer.rb',
+                      'lib/job_interview/hello_world.rb',
                       'lib/job_interview/questions.rb',
                       'lib/job_interview/primes.rb',
                       'lib/job_interview/quine.rb']


### PR DESCRIPTION
Added to resolve the following error. 

```
1.9.3p392 :001 > require 'job_interview'
LoadError: cannot load such file -- /Users/gregwoods/.rvm/gems/ruby-1.9.3-p392/gems/job_interview-0.1.4/lib/job_interview/hello_world
  from /Users/gregwoods/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
  from /Users/gregwoods/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
  from /Users/gregwoods/.rvm/gems/ruby-1.9.3-p392/gems/job_interview-0.1.4/lib/job_interview.rb:3:in `<top (required)>'
  from /Users/gregwoods/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
  from /Users/gregwoods/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
  from /Users/gregwoods/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
  from (irb):1
  from /Users/gregwoods/.rvm/rubies/ruby-1.9.3-p392/bin/irb:16:in `<main>'
```
