### PR TITLE
quine uses caller's filename if no argument is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ require 'job_interview'
  => [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 
 # Quine
-@answer.quine(__FILE__)
- => "@answer.quine(__FILE__)"
+@answer.quine
+ => "@answer.quine"
 
 # The first n primes
 @answer.primes(10)

--- a/lib/job_interview/quine.rb
+++ b/lib/job_interview/quine.rb
@@ -1,7 +1,8 @@
 module JobInterview
   module Quine
     
-    def quine(file)
+    def quine(file = nil)
+      file ||= caller.first.split(':').first
       return File.read(file)
     end
     

--- a/spec/quine_spec.rb
+++ b/spec/quine_spec.rb
@@ -9,6 +9,10 @@ module QuineSpec
     it "should return the source of the calling file" do
       @answer.quine(__FILE__).should == File.read(__FILE__)
     end
+
+    it "should find the calling file if not given" do
+      @answer.quine.should == File.read(__FILE__)
+    end
   end
 
 


### PR DESCRIPTION
Make life easier for interviewees.
