### PR TITLE
updating deprecated 'source :rubygems'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       faker (~> 0.9.5)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     colorize (0.5.8)
     coveralls (0.6.2)


### PR DESCRIPTION
'source :rubygems' has been deprecated - it's recommended to use 'source "https://rubygems.org"' instead.
